### PR TITLE
Set certbot as default LE client

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -6,16 +6,8 @@
 
 - name: Installs certbot
   apt:
-    pkg: python-certbot
-    state: present
-  ignore_errors: true
-  register: __haproxy_le_python_certbot
-
-- name: Installs certbot
-  apt:
     pkg: certbot
     state: present
-  when: __haproxy_le_python_certbot | failed
 
 - name: Creates certificate & lua dirs in haproxy config dir
   file:


### PR DESCRIPTION
Installation de certbot aulieu d'uniquement python-certbot (qui est une dépendance de certbot).
Certbot est nécessaire pour l'execution du script de renew poussé par le rôle.